### PR TITLE
Add client-side logging with popup dialog

### DIFF
--- a/components/LogDialog.vue
+++ b/components/LogDialog.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Button } from '@/components/ui/button'
+import { getLogs, clearLogs, LogEntry } from '@/lib/logger'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits(['update:modelValue'])
+
+const logs = ref<LogEntry[]>([])
+
+function refresh() {
+  logs.value = getLogs().reverse()
+}
+
+watch(() => props.modelValue, (val) => {
+  if (val) {
+    refresh()
+  }
+})
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function clearAll() {
+  clearLogs()
+  refresh()
+}
+</script>
+
+<template>
+  <div v-if="modelValue" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div class="bg-background text-foreground max-w-md w-full p-4 rounded-lg shadow-lg">
+      <h2 class="text-lg font-semibold mb-4">Logs</h2>
+      <div class="max-h-60 overflow-y-auto mb-4 text-sm space-y-2">
+        <div v-for="log in logs" :key="log.id" class="border-b pb-1">
+          <div class="text-xs text-muted-foreground">{{ log.time }} - {{ log.type }}</div>
+          <pre class="whitespace-pre-wrap">{{ JSON.stringify(log.data, null, 2) }}</pre>
+        </div>
+        <div v-if="!logs.length" class="text-center text-muted-foreground">No logs</div>
+      </div>
+      <div class="flex justify-end gap-2">
+        <Button @click="clearAll">Clear</Button>
+        <Button @click="close">Close</Button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Menu as MenuIcon, X as CloseIcon } from 'lucide-vue-next'
+import LogDialog from '@/components/LogDialog.vue'
 
 const mobileOpen = ref(false)
+const logsOpen = ref(false)
 </script>
 
 <template>
@@ -23,6 +25,7 @@ const mobileOpen = ref(false)
           <NuxtLink to="/calendar-history" class="hover:underline">Calendar</NuxtLink>
           <NuxtLink to="/foods-recipes" class="hover:underline">Foods</NuxtLink>
           <NuxtLink to="/profile-settings" class="hover:underline">Profile</NuxtLink>
+          <button @click="logsOpen = true" class="hover:underline">Logs</button>
         </nav>
       </div>
       <nav
@@ -42,11 +45,15 @@ const mobileOpen = ref(false)
           <li>
             <NuxtLink @click="mobileOpen = false" to="/profile-settings" class="block py-1">Profile</NuxtLink>
           </li>
+          <li>
+            <button @click="mobileOpen = false; logsOpen = true" class="block py-1 w-full text-left">Logs</button>
+          </li>
         </ul>
       </nav>
     </header>
     <main class="p-4 max-w-md mx-auto">
       <NuxtPage />
     </main>
+    <LogDialog v-model="logsOpen" />
   </div>
 </template>

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,28 @@
+export interface LogEntry {
+  id: string
+  type: string
+  data: any
+  time: string
+}
+
+const LOG_KEY = 'appLogs'
+
+export function getLogs(): LogEntry[] {
+  const raw = localStorage.getItem(LOG_KEY)
+  return raw ? JSON.parse(raw) : []
+}
+
+export function addLog(type: string, data: any) {
+  const logs = getLogs()
+  logs.push({
+    id: 'l' + Date.now(),
+    type,
+    data,
+    time: new Date().toISOString()
+  })
+  localStorage.setItem(LOG_KEY, JSON.stringify(logs))
+}
+
+export function clearLogs() {
+  localStorage.removeItem(LOG_KEY)
+}

--- a/pages/meal-logging.vue
+++ b/pages/meal-logging.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { getFoods, getMeals, saveMeals, type Food } from '@/lib/db'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+const { $logger } = useNuxtApp()
 
 const foods = ref<Food[]>([])
 const query = ref('')
@@ -23,6 +24,7 @@ function addToLog(food: Food) {
     items: [{ type: 'food', id: food.food_id, quantity: qty }]
   })
   saveMeals(meals)
+  $logger.log('meal-added', { food: food.name, quantity: qty })
   quantities.value[food.food_id] = 1
 }
 

--- a/plugins/logger.client.ts
+++ b/plugins/logger.client.ts
@@ -1,0 +1,26 @@
+import { addLog, getLogs, clearLogs } from '@/lib/logger'
+
+export default defineNuxtPlugin(() => {
+  if (!process.client) return
+
+  const wrap = (type: string, fn: (...args: any[]) => void) => {
+    return (...args: any[]) => {
+      addLog(type, args)
+      fn(...args)
+    }
+  }
+
+  console.log = wrap('log', console.log.bind(console))
+  console.warn = wrap('warn', console.warn.bind(console))
+  console.error = wrap('error', console.error.bind(console))
+
+  return {
+    provide: {
+      logger: {
+        log: addLog,
+        getLogs,
+        clearLogs,
+      },
+    },
+  }
+})


### PR DESCRIPTION
## Summary
- implement a tiny logger that saves messages in localStorage
- capture console output with a logger plugin
- add a LogDialog component to display saved logs
- expose dialog from the layout
- log meal additions using the new logger

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dac4158b08330af09b5990e91af3a